### PR TITLE
fix: upgrade streamlit to 1.56.0 to address security vulnerabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ __pycache__/
 */.DS_Store
 .idea/
 
+# Virtual environment
+.venv/
+
 # Secrets
 llm-chatbot-python/.streamlit/
 

--- a/llm-chatbot-python/requirements.txt
+++ b/llm-chatbot-python/requirements.txt
@@ -3,7 +3,7 @@ langchain==0.3.9
 openai==1.68.2
 langchain-openai==0.3.10
 neo4j-driver==5.21.0
-streamlit==1.37.0
+streamlit==1.56.0
 langchainhub==0.1.21
 langchain-neo4j==0.1.1
 langchain-community

--- a/llm-chatbot-python/utils.py
+++ b/llm-chatbot-python/utils.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from streamlit.runtime.scriptrunner.script_run_context import get_script_run_ctx
+from streamlit.runtime.scriptrunner import get_script_run_ctx
 
 # tag::write_message[]
 def write_message(role, content, save = True):


### PR DESCRIPTION
## Summary

- Upgrades `streamlit` from `1.37.0` to `1.56.0` to address two security advisories:
  - [GHSA-7p48-42j8-8846](https://github.com/streamlit/streamlit/security/advisories/GHSA-7p48-42j8-8846) — Unauthenticated SSRF / NTLM credential exposure on Windows (CVE-2026-33682, fixed in 1.54.0)
  - [GHSA-rxff-vr5r-8cj5](https://github.com/streamlit/streamlit/security/advisories/GHSA-rxff-vr5r-8cj5) — Path traversal on Windows (CVE-2024-42474, already fixed in 1.37.0)
- Fixes a compatibility breaking change introduced in streamlit 1.54.0: the internal module `streamlit.runtime.scriptrunner.script_run_context` was merged into `streamlit.runtime.scriptrunner`. Updated the import in `utils.py` accordingly.

## Changes

- `llm-chatbot-python/requirements.txt`: `streamlit==1.37.0` → `streamlit==1.56.0`
- `llm-chatbot-python/utils.py`: updated `get_script_run_ctx` import path

## Compatibility

All public Streamlit APIs used in this project (`st.chat_input`, `st.chat_message`, `st.spinner`, `st.session_state`, `st.secrets`, `st.selectbox`, `st.sidebar`, etc.) are fully compatible with 1.56.0. Verified against the full changelog from 1.37.0 to 1.56.0.

Made with [Cursor](https://cursor.com)